### PR TITLE
[WIP] Add support for using multiple CRDs in a template

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -84,5 +84,7 @@ func check(out io.Writer) error {
 		return err
 	}
 	cr := &tmpl.CustomResource{Resource: &r}
-	return tmpl.Parse(cr, filepath.Join(tmplDir, "*.tmpl"), out)
+	crs := tmpl.NewCustomResources()
+	crs.AddResource(cr)
+	return tmpl.Parse(crs, filepath.Join(tmplDir, "*.tmpl"), out)
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -150,7 +150,8 @@ func getController() crwatcher.ResourceController {
 	}
 	logger = logger.With("controller", "template")
 	logger.Infow("using template controller for deployment", "templateDir", viper.GetString("templates"))
-	return tmplctlr.NewController(viper.GetString("templates"), viper.GetString("k8s.config"), logger)
+	viper.SetDefault("batchMode", false)
+	return tmplctlr.NewController(viper.GetString("templates"), viper.GetString("k8s.config"), logger, viper.GetBool("batchMode"))
 }
 
 type crLogger struct {

--- a/crwatcher/mocks_test.go
+++ b/crwatcher/mocks_test.go
@@ -62,3 +62,8 @@ func (_m *MockResourceController) ResourceDeleted(resource *unstructured.Unstruc
 func (_mr *MockResourceControllerMockRecorder) ResourceDeleted(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "ResourceDeleted", reflect.TypeOf((*MockResourceController)(nil).ResourceDeleted), arg0)
 }
+
+// ResourceDeleted mocks base method
+func (_m *MockResourceController) SetSynced() {
+	_m.ctrl.Call(_m, "SetSynced")
+}

--- a/crwatcher/mocks_test.go
+++ b/crwatcher/mocks_test.go
@@ -64,6 +64,6 @@ func (_mr *MockResourceControllerMockRecorder) ResourceDeleted(arg0 interface{})
 }
 
 // ResourceDeleted mocks base method
-func (_m *MockResourceController) SetSynced() {
+func (_m *MockResourceController) NotifySynced() {
 	_m.ctrl.Call(_m, "SetSynced")
 }

--- a/crwatcher/watcher.go
+++ b/crwatcher/watcher.go
@@ -69,7 +69,7 @@ type ResourceController interface {
 	ResourceAdded(resource *unstructured.Unstructured)
 	ResourceUpdated(oldResource, newResource *unstructured.Unstructured)
 	ResourceDeleted(resource *unstructured.Unstructured)
-	SetSynced()
+	NotifySynced()
 }
 
 // ErrorLogger will receive any error messages from the kubernetes client
@@ -208,7 +208,7 @@ func (cw *CRWatcher) Watch(stopCh <-chan struct{}) error {
 	// starts after this.
 	go func(){
 		cache.WaitForCacheSync(stopCh, cw.controller.HasSynced)
-		cw.resourceController.SetSynced()
+		cw.resourceController.NotifySynced()
 	}()
 
 	cw.controller.Run(stopCh)

--- a/helmctlr/helm.go
+++ b/helmctlr/helm.go
@@ -38,6 +38,11 @@ type Controller struct {
 	Wait        bool           // Whether or not to wait for resources during Update and Install before marking a release successful
 	WaitTimeout int64          // time in seconds to wait for kubernetes resources to be created before marking a release successful
 	logger      *zap.SugaredLogger
+	synced      bool
+}
+
+func (c *Controller) SetSynced(){
+	c.synced = true
 }
 
 // NewController will return a configured Helm Controller

--- a/helmctlr/helm.go
+++ b/helmctlr/helm.go
@@ -41,7 +41,7 @@ type Controller struct {
 	synced      bool
 }
 
-func (c *Controller) SetSynced(){
+func (c *Controller) NotifySynced(){
 	c.synced = true
 }
 

--- a/printctlr/controller.go
+++ b/printctlr/controller.go
@@ -57,7 +57,7 @@ func (c Controller) ResourceDeleted(r *unstructured.Unstructured) {
 	metrics.LastSuccessfulDelete.Set(float64(time.Now().UTC().UnixNano()) / 1000000000)
 }
 
-func (c Controller) SetSynced() {
+func (c Controller) NotifySynced() {
 	// noop
 	return
 }

--- a/printctlr/controller.go
+++ b/printctlr/controller.go
@@ -56,3 +56,8 @@ func (c Controller) ResourceDeleted(r *unstructured.Unstructured) {
 	metrics.TotalEvents.Inc()
 	metrics.LastSuccessfulDelete.Set(float64(time.Now().UTC().UnixNano()) / 1000000000)
 }
+
+func (c Controller) SetSynced() {
+	// noop
+	return
+}

--- a/tmpl/custom_resource.go
+++ b/tmpl/custom_resource.go
@@ -14,7 +14,10 @@
 
 package tmpl
 
-import "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"fmt"
+)
 
 // CustomResource provides some helper methods for interacting with the
 // kubernetes custom resource inside the templates.
@@ -44,6 +47,9 @@ func getNestedField(obj map[string]interface{}, fields ...string) interface{} {
 			return nil
 		}
 		val = val.(map[string]interface{})[field]
+		if _, ok := val.(int64); ok {
+			val = fmt.Sprint(val)
+		}
 	}
 	return val
 }

--- a/tmpl/custom_resource_test.go
+++ b/tmpl/custom_resource_test.go
@@ -30,6 +30,11 @@ func TestGetField(t *testing.T) {
 	assert.Equal(t, "dory", r)
 }
 
+func TestGetNumericField(t *testing.T) {
+	r := testCR.GetField("spec", "Likes")
+	assert.Equal(t, "32", r)
+}
+
 func TestGetFieldReturnsEmptyIfNotFound(t *testing.T) {
 	r := testCR.GetField("Something", "made", "up")
 	assert.Empty(t, r)

--- a/tmpl/custom_resources.go
+++ b/tmpl/custom_resources.go
@@ -62,6 +62,11 @@ func (crs *CustomResources) GetResources(kind string, apiVersion string) []*Cust
 	return resources
 }
 
+// Forget all CRDs the template knows about
+func (crs *CustomResources) PurgeResources() {
+	crs.Resources = make(map[string]map[string]*CustomResource)
+}
+
 // Emulate legacy behavior if only one CustomResource
 func (crs *CustomResources) Name() string {
 	if crs.lastResource != nil {

--- a/tmpl/custom_resources.go
+++ b/tmpl/custom_resources.go
@@ -77,3 +77,11 @@ func (crs *CustomResources) GetField(fields ...string) string {
 	}
 	return ""
 }
+
+func (crs *CustomResources) Count() int {
+	count := 0
+	for _, v := range crs.Resources {
+		count += len(v)
+	}
+	return count
+}

--- a/tmpl/custom_resources.go
+++ b/tmpl/custom_resources.go
@@ -1,0 +1,68 @@
+// Copyright 2017 the lostromos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tmpl
+
+// CustomResource provides some helper methods for interacting with the
+// kubernetes custom resource inside the templates.
+type CustomResources struct {
+	Resources map[string]map[string]*CustomResource // represents the resource from kubernetes
+	lastResource *CustomResource // points to the last added resource
+}
+
+func NewCustomResources() *CustomResources {
+	crs := &CustomResources{
+		Resources: make(map[string]map[string]*CustomResource),
+	}
+	return crs
+}
+
+func (crs *CustomResources) AddResource(cr *CustomResource) {
+	crKind := cr.Resource.GetAPIVersion() + "/" + cr.Resource.GetKind()
+	if _, ok := crs.Resources[crKind]; !ok {
+		crs.Resources[crKind] = make(map[string]*CustomResource)
+	}
+	crs.Resources[crKind][cr.Resource.GetSelfLink()] = cr
+
+	// Emulate legacy behavior if only one CustomResource
+	crs.lastResource = cr
+}
+
+func (crs *CustomResources) DeleteResource(cr *CustomResource) {
+	crKind := cr.Resource.GetAPIVersion() + "/" + cr.Resource.GetKind()
+	if _, ok := crs.Resources[crKind]; ok {
+		delete(crs.Resources[crKind], cr.Resource.GetSelfLink())
+	}
+}
+
+func (crs *CustomResources) GetResources(kind string, apiVersion string) []*CustomResource {
+	crKind := apiVersion + "/" + kind
+	resources := make([]*CustomResource,0)
+	if _, ok := crs.Resources[crKind]; !ok {
+		return resources
+	}
+	for _, resource := range crs.Resources[crKind] {
+		resources = append(resources, resource)
+	}
+	return resources
+}
+
+// Emulate legacy behavior if only one CustomResource
+func (crs *CustomResources) Name() string {
+	return crs.lastResource.Name()
+}
+
+func (crs *CustomResources) GetField(fields ...string) string {
+	return crs.lastResource.GetField(fields...)
+}

--- a/tmpl/custom_resources.go
+++ b/tmpl/custom_resources.go
@@ -42,6 +42,10 @@ func (crs *CustomResources) AddResource(cr *CustomResource) {
 func (crs *CustomResources) DeleteResource(cr *CustomResource) {
 	crKind := cr.Resource.GetAPIVersion() + "/" + cr.Resource.GetKind()
 	if _, ok := crs.Resources[crKind]; ok {
+		oldResource := crs.Resources[crKind][cr.Resource.GetSelfLink()]
+		if &crs.lastResource == &oldResource {
+			crs.lastResource = nil
+		}
 		delete(crs.Resources[crKind], cr.Resource.GetSelfLink())
 	}
 }
@@ -60,9 +64,16 @@ func (crs *CustomResources) GetResources(kind string, apiVersion string) []*Cust
 
 // Emulate legacy behavior if only one CustomResource
 func (crs *CustomResources) Name() string {
-	return crs.lastResource.Name()
+	if crs.lastResource != nil {
+		return crs.lastResource.Name()
+	}
+	return ""
 }
 
+
 func (crs *CustomResources) GetField(fields ...string) string {
-	return crs.lastResource.GetField(fields...)
+	if crs.lastResource != nil {
+		return crs.lastResource.GetField(fields...)
+	}
+	return ""
 }

--- a/tmpl/custom_resources_test.go
+++ b/tmpl/custom_resources_test.go
@@ -12,20 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tmpl
+package tmpl_test
 
 import (
-	"io"
-	"text/template"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wpengine/lostromos/tmpl"
 )
 
-// Parse will take a CustomResource, template directory and an io.Writer and
-// print the resulting templates to the io.Writer
-func Parse(crs *CustomResources, dir string, w io.Writer) error {
-	tmpl, err := template.ParseGlob(dir)
-	if err != nil {
-		return err
-	}
-
-	return tmpl.Execute(w, crs)
+func TestAddResource(t *testing.T) {
+	crs := tmpl.NewCustomResources()
+	crs.AddResource(testCR)
+	assert.Equal(t, "dory", crs.Name())
 }

--- a/tmpl/custom_resources_test.go
+++ b/tmpl/custom_resources_test.go
@@ -26,3 +26,16 @@ func TestAddResource(t *testing.T) {
 	crs.AddResource(testCR)
 	assert.Equal(t, "dory", crs.Name())
 }
+
+func TestDeleteResource(t *testing.T) {
+	crs := tmpl.NewCustomResources()
+	crs.DeleteResource(testCR)
+	assert.Equal(t, "", crs.Name())
+}
+
+func TestGetResources(t *testing.T) {
+	crs := tmpl.NewCustomResources()
+	crs.AddResource(testCR)
+	resources := crs.GetResources(testCR.Resource.GetKind(), testCR.Resource.GetAPIVersion())
+	assert.Equal(t, "dory", resources[0].Name())
+}

--- a/tmpl/parse_test.go
+++ b/tmpl/parse_test.go
@@ -31,8 +31,11 @@ import (
 var (
 	testResource = &unstructured.Unstructured{
 		Object: map[string]interface{}{
+			"apiVersion": "stable.nicolerenee.io/v1",
+			"kind": "Character",
 			"metadata": map[string]interface{}{
 				"name": "dory",
+				"selfLink": "/api/stable.nicolerenee.io/v1/namespaces/mock/characters/dory",
 			},
 			"spec": map[string]interface{}{
 				"Name": "Dory",

--- a/tmpl/parse_test.go
+++ b/tmpl/parse_test.go
@@ -86,8 +86,10 @@ func TestParse(t *testing.T) {
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
 
+	testCRs := tmpl.NewCustomResources()
+	testCRs.AddResource(testCR)
 	buf := bytes.NewBufferString("")
-	err := tmpl.Parse(testCR, filepath.Join(dir, "*.tmpl"), buf)
+	err := tmpl.Parse(testCRs, filepath.Join(dir, "*.tmpl"), buf)
 	assert.Nil(t, err)
 	assert.NotNil(t, buf.String())
 	assert.Equal(t, "--- name: dory-configmap", buf.String())
@@ -97,7 +99,9 @@ func TestGenerateTemplateNoTemplatePath(t *testing.T) {
 	buf := bytes.NewBufferString("")
 	assert.Empty(t, buf.String(), "Buffer is new, it should be empty")
 
-	err := tmpl.Parse(testCR, "", buf)
+	testCRs := tmpl.NewCustomResources()
+	testCRs.AddResource(testCR)
+	err := tmpl.Parse(testCRs, "", buf)
 
 	assert.NotNil(t, err)
 	assert.Empty(t, buf.String(), "If an error occurs nothing should be written")

--- a/tmpl/parse_test.go
+++ b/tmpl/parse_test.go
@@ -38,6 +38,7 @@ var (
 				"Name": "Dory",
 				"From": "Finding Nemo",
 				"By":   "Disney",
+				"Likes": int64(32),
 			},
 		},
 	}

--- a/tmplctlr/controller.go
+++ b/tmplctlr/controller.go
@@ -55,7 +55,7 @@ func NewController(tmplDir string, kubeCfg string, logger *zap.SugaredLogger) *C
 	return c
 }
 
-func (c *Controller) SetSynced(){
+func (c *Controller) NotifySynced(){
 	c.synced = true
 	// Trigger a template build since we're synced now
 	out, err := c.apply(nil)

--- a/tmplctlr/controller.go
+++ b/tmplctlr/controller.go
@@ -38,7 +38,7 @@ type Controller struct {
 }
 
 // NewController will return a configured Controller
-func NewController(tmplDir string, kubeCfg string, logger *zap.SugaredLogger) *Controller {
+func NewController(tmplDir string, kubeCfg string, logger *zap.SugaredLogger, batchMode bool) *Controller {
 	if logger == nil {
 		// If you don't give us a logger, set logger to a nop logger
 		logger = zap.NewNop().Sugar()
@@ -50,7 +50,7 @@ func NewController(tmplDir string, kubeCfg string, logger *zap.SugaredLogger) *C
 		logger:       logger,
 		Resources:    resources,
 		synced:       false,
-		batchMode:    false,
+		batchMode:    batchMode,
 	}
 	return c
 }
@@ -118,7 +118,7 @@ func (c Controller) apply(r *unstructured.Unstructured) (output string, err erro
 		cr := &tmpl.CustomResource{
 			Resource: r,
 		}
-		if c.batchMode {
+		if !c.batchMode {
 			c.Resources.PurgeResources()
 		}
 		c.Resources.AddResource(cr)

--- a/tmplctlr/controller.go
+++ b/tmplctlr/controller.go
@@ -122,6 +122,7 @@ func (c Controller) delete(r *unstructured.Unstructured) (output string, err err
 	}
 	c.Resources.DeleteResource(cr)
 	if c.Resources.Count() > 0 {
+		// FIXME: This will miss resources with a 1:1 CRD:Resource mapping
 		return c.apply(nil)
 	} else {
 		return c.Client.Delete(tmpFile.Name())

--- a/tmplctlr/controller_test.go
+++ b/tmplctlr/controller_test.go
@@ -188,7 +188,7 @@ func TestResourceAddedHappyPath(t *testing.T) {
 	dir := createTestDir(testTemplates)
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
-	c := tmplctlr.NewController(dir, "", nil)
+	c := tmplctlr.NewController(dir, "", nil, false)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockKube := NewMockKubeClient(mockCtrl)
@@ -211,7 +211,7 @@ func TestResourceAddedApplyFails(t *testing.T) {
 	dir := createTestDir(testTemplates)
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
-	c := tmplctlr.NewController(dir, "", nil)
+	c := tmplctlr.NewController(dir, "", nil, false)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockKube := NewMockKubeClient(mockCtrl)
@@ -232,7 +232,7 @@ func TestResourceAddedTemplatingFails(t *testing.T) {
 	dir := createTestDir(testBadTemplates)
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
-	c := tmplctlr.NewController(dir, "", nil)
+	c := tmplctlr.NewController(dir, "", nil, false)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockKube := NewMockKubeClient(mockCtrl)
@@ -251,7 +251,7 @@ func TestResourceDeletedHappyPath(t *testing.T) {
 	dir := createTestDir(testTemplates)
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
-	c := tmplctlr.NewController(dir, "", nil)
+	c := tmplctlr.NewController(dir, "", nil, false)
 	c.ResourceAdded(testResource);
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -275,7 +275,7 @@ func TestResourceDeletedApplyFails(t *testing.T) {
 	dir := createTestDir(testTemplates)
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
-	c := tmplctlr.NewController(dir, "", nil)
+	c := tmplctlr.NewController(dir, "", nil, false)
 	c.ResourceAdded(testResource);
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -297,7 +297,7 @@ func TestResourceDeletedTemplatingFails(t *testing.T) {
 	dir := createTestDir(testBadTemplates)
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
-	c := tmplctlr.NewController(dir, "", nil)
+	c := tmplctlr.NewController(dir, "", nil, false)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockKube := NewMockKubeClient(mockCtrl)
@@ -316,7 +316,7 @@ func TestResourceUpdatedHappyPath(t *testing.T) {
 	dir := createTestDir(testTemplates)
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
-	c := tmplctlr.NewController(dir, "", nil)
+	c := tmplctlr.NewController(dir, "", nil, false)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockKube := NewMockKubeClient(mockCtrl)
@@ -338,7 +338,7 @@ func TestResourceUpdatedApplyFails(t *testing.T) {
 	dir := createTestDir(testTemplates)
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
-	c := tmplctlr.NewController(dir, "", nil)
+	c := tmplctlr.NewController(dir, "", nil, false)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockKube := NewMockKubeClient(mockCtrl)

--- a/tmplctlr/controller_test.go
+++ b/tmplctlr/controller_test.go
@@ -189,7 +189,6 @@ func TestResourceAddedHappyPath(t *testing.T) {
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
 	c := tmplctlr.NewController(dir, "", nil)
-	c.SetSynced()
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockKube := NewMockKubeClient(mockCtrl)
@@ -213,7 +212,6 @@ func TestResourceAddedApplyFails(t *testing.T) {
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
 	c := tmplctlr.NewController(dir, "", nil)
-	c.SetSynced()
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockKube := NewMockKubeClient(mockCtrl)
@@ -235,7 +233,6 @@ func TestResourceAddedTemplatingFails(t *testing.T) {
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
 	c := tmplctlr.NewController(dir, "", nil)
-	c.SetSynced()
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockKube := NewMockKubeClient(mockCtrl)
@@ -255,7 +252,6 @@ func TestResourceDeletedHappyPath(t *testing.T) {
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
 	c := tmplctlr.NewController(dir, "", nil)
-	c.SetSynced()
 	c.ResourceAdded(testResource);
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -280,7 +276,6 @@ func TestResourceDeletedApplyFails(t *testing.T) {
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
 	c := tmplctlr.NewController(dir, "", nil)
-	c.SetSynced()
 	c.ResourceAdded(testResource);
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -303,7 +298,6 @@ func TestResourceDeletedTemplatingFails(t *testing.T) {
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
 	c := tmplctlr.NewController(dir, "", nil)
-	c.SetSynced()
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockKube := NewMockKubeClient(mockCtrl)
@@ -323,7 +317,6 @@ func TestResourceUpdatedHappyPath(t *testing.T) {
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
 	c := tmplctlr.NewController(dir, "", nil)
-	c.SetSynced()
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockKube := NewMockKubeClient(mockCtrl)
@@ -346,7 +339,6 @@ func TestResourceUpdatedApplyFails(t *testing.T) {
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
 	c := tmplctlr.NewController(dir, "", nil)
-	c.SetSynced()
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockKube := NewMockKubeClient(mockCtrl)

--- a/tmplctlr/controller_test.go
+++ b/tmplctlr/controller_test.go
@@ -35,8 +35,11 @@ import (
 var (
 	testResource = &unstructured.Unstructured{
 		Object: map[string]interface{}{
+			"apiVersion": "stable.nicolerenee.io/v1",
+			"kind": "Character",
 			"metadata": map[string]interface{}{
 				"name": "dory",
+				"selfLink": "/api/stable.nicolerenee.io/v1/namespaces/mock/characters/dory",
 			},
 			"spec": map[string]interface{}{
 				"Name": "Dory",
@@ -249,6 +252,7 @@ func TestResourceDeletedHappyPath(t *testing.T) {
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
 	c := tmplctlr.NewController(dir, "", nil)
+	c.ResourceAdded(testResource);
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockKube := NewMockKubeClient(mockCtrl)
@@ -272,6 +276,7 @@ func TestResourceDeletedApplyFails(t *testing.T) {
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
 	c := tmplctlr.NewController(dir, "", nil)
+	c.ResourceAdded(testResource);
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockKube := NewMockKubeClient(mockCtrl)

--- a/tmplctlr/controller_test.go
+++ b/tmplctlr/controller_test.go
@@ -189,6 +189,7 @@ func TestResourceAddedHappyPath(t *testing.T) {
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
 	c := tmplctlr.NewController(dir, "", nil)
+	c.SetSynced()
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockKube := NewMockKubeClient(mockCtrl)
@@ -212,6 +213,7 @@ func TestResourceAddedApplyFails(t *testing.T) {
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
 	c := tmplctlr.NewController(dir, "", nil)
+	c.SetSynced()
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockKube := NewMockKubeClient(mockCtrl)
@@ -233,6 +235,7 @@ func TestResourceAddedTemplatingFails(t *testing.T) {
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
 	c := tmplctlr.NewController(dir, "", nil)
+	c.SetSynced()
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockKube := NewMockKubeClient(mockCtrl)
@@ -252,6 +255,7 @@ func TestResourceDeletedHappyPath(t *testing.T) {
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
 	c := tmplctlr.NewController(dir, "", nil)
+	c.SetSynced()
 	c.ResourceAdded(testResource);
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -276,6 +280,7 @@ func TestResourceDeletedApplyFails(t *testing.T) {
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
 	c := tmplctlr.NewController(dir, "", nil)
+	c.SetSynced()
 	c.ResourceAdded(testResource);
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -298,6 +303,7 @@ func TestResourceDeletedTemplatingFails(t *testing.T) {
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
 	c := tmplctlr.NewController(dir, "", nil)
+	c.SetSynced()
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockKube := NewMockKubeClient(mockCtrl)
@@ -317,6 +323,7 @@ func TestResourceUpdatedHappyPath(t *testing.T) {
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
 	c := tmplctlr.NewController(dir, "", nil)
+	c.SetSynced()
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockKube := NewMockKubeClient(mockCtrl)
@@ -339,6 +346,7 @@ func TestResourceUpdatedApplyFails(t *testing.T) {
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
 	c := tmplctlr.NewController(dir, "", nil)
+	c.SetSynced()
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockKube := NewMockKubeClient(mockCtrl)


### PR DESCRIPTION
## Problem Statement
Templates are currently rendered per-CRD. We have a case for generating templates that are composed of many CRDs.  e.g. generating a config file where each CRD represents a config block of that file. 

## Solution
- Adds a CustomResources struct to manage CRDs for a template
- Updates template controller and parser to use the CustomResources manager
- Introduces `batchMode` config option for template rendering. When true, CRDs are batched together, and then rendered, rather than rendered per-CRD.
- Introduces `.GetResources` method which can be used to access the list of CRDs from the template
- Maintains compatibility of `.GetField` and `.Name` calls when not using multiple CRDs.